### PR TITLE
Replaced comma in numbers format to Indian format (#28)

### DIFF
--- a/app/utils/prepareAnswer.js
+++ b/app/utils/prepareAnswer.js
@@ -1,30 +1,37 @@
-function numberWithCommas(x) {
-    return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-}
+function numberWithIndianCommas(x){
+    var y = x.toString()
+    if (y.length > 3) {
+        var z = y.substr(y.length - 3, 3)
+        y = y.substr(0, y.length - 3)
+        y = y.replace(/\B(?=(\d{2})+(?!\d))/g, ",")
+        return y + ',' + z
+    }
+    else return y
+    }
 
 function prepareStatsCompactAnswer(body, index, nameState) {
     let statewise = body['statewise']
     let statedata = statewise[index]
     let data = '<b>' + nameState + '</b>'
-    data += "\n\u{1F534} Confirmed: " + numberWithCommas(statedata['confirmed'])
+    data += "\n\u{1F534} Confirmed: " + numberWithIndianCommas(statedata['confirmed'])
     if (parseInt(statedata['deltaconfirmed']) > 0) {
-        data += '<i> (+' + numberWithCommas(statedata['deltaconfirmed']) + ')</i>'
+        data += '<i> (+' + numberWithIndianCommas(statedata['deltaconfirmed']) + ')</i>'
     }
-    data += "\n\u{1F7E0} Active: " + numberWithCommas(statedata['active'])
-    data += "\n\u{1F7E2} Recovered: " + numberWithCommas(statedata['recovered'])
+    data += "\n\u{1F7E0} Active: " + numberWithIndianCommas(statedata['active'])
+    data += "\n\u{1F7E2} Recovered: " + numberWithIndianCommas(statedata['recovered'])
     if (parseInt(statedata['deltarecovered']) > 0) {
-        data += '<i> (+' + numberWithCommas(statedata['deltarecovered']) + ')</i>'
+        data += '<i> (+' + numberWithIndianCommas(statedata['deltarecovered']) + ')</i>'
     }
-    data += "\n\u{26AB} Deaths: " + numberWithCommas(statedata['deaths'])
+    data += "\n\u{26AB} Deaths: " + numberWithIndianCommas(statedata['deaths'])
     if (parseInt(statedata['deltadeaths']) > 0) {
-        data += '<i> (+' + numberWithCommas(statedata['deltadeaths']) + ')</i>'
+        data += '<i> (+' + numberWithIndianCommas(statedata['deltadeaths']) + ')</i>'
     }
     return data
 }
 
 function prepareAllIndiaCasesTested(body) {
     let noOfTests = body['tested'].reverse()[0]['totalsamplestested'];
-    data = '\n\u{26AA} ' + numberWithCommas(noOfTests) + ' citizens tested';
+    data = '\n\u{26AA} ' + numberWithIndianCommas(noOfTests) + ' citizens tested';
     return data;
 }
 
@@ -40,9 +47,9 @@ function prepareStatsStateAnswer(body) {
     statewise.forEach((object, index) => {
         if (index == 0 || index > 15)
             return
-        data += '\n<b>' + object['state'] + '</b>: ' + object['confirmed']
+        data += '\n<b>' + object['state'] + '</b>: ' + numberWithIndianCommas(object['confirmed'])
         if (parseInt(object['deltaconfirmed']) > 0) {
-            data += '<i> (+' + numberWithCommas(object['deltaconfirmed']) + ') </i>'
+            data += '<i> (+' + numberWithIndianCommas(object['deltaconfirmed']) + ') </i>'
         }
     });
     return data
@@ -66,10 +73,10 @@ function prepareStatsDistrictAnswer(body, stateName) {
     let data = '\n\n\u{1F4C8} District-wise analysis'
     for (var i = 0; i < sortedData.length; i++) {
         let eachDistrictData = districtData[sortedData[i].name]
-        data += '\n<b>' + sortedData[i].name + '</b>: ' + numberWithCommas(eachDistrictData['confirmed'])
+        data += '\n<b>' + sortedData[i].name + '</b>: ' + numberWithIndianCommas(eachDistrictData['confirmed'])
         let deltaData = eachDistrictData['delta']
         if (parseInt(deltaData['confirmed']) > 0) {
-            data += '<i> (+' + numberWithCommas(deltaData['confirmed']) + ') </i>'
+            data += '<i> (+' + numberWithIndianCommas(deltaData['confirmed']) + ') </i>'
         }
     }
     return data
@@ -83,7 +90,7 @@ function prepareDailyStatsAnswer(body, n) {
     for (let i = 0; i < n; i++) {
         let date = dailyData[i].date
         date = date.substring(0, date.length - 1);
-        data += '\n<b>' + date + '</b>: ' + numberWithCommas(dailyData[i].dailyconfirmed) + ' new cases.'
+        data += '\n<b>' + date + '</b>: ' + numberWithIndianCommas(dailyData[i].dailyconfirmed) + ' new cases.'
     }
     return data
 }


### PR DESCRIPTION
* Replaced comma in numbers format to Indian format

The result will now display with the Indian number format (10,00,000 instead of 1,000,000)

* Minor change for stats using command /all

All stats did not include commas for the number of cases for states(Top 15 states with most cases). Edited it and now states stats will include commas when displayed using /all command.